### PR TITLE
Fix README formatting of default scripts

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -120,10 +120,10 @@ and then running `pnpm release` or `pnpm exec release` will call `lionp`.
 
 To reduce boilerplate in the `scripts` property of each codebase's `package.json`, some utility binaries are exposed:
 
-`pnpm exec test`: `vitest run`\
-`pnpm exec lint`: `eslint --cache --fix .`\
-`pnpm exec format`: `prettier --write .`\
-`pnpm exec typecheck`: `tsc --noEmit`
+- `pnpm exec test`: `vitest run`
+- `pnpm exec lint`: `eslint --cache --fix .`
+- `pnpm exec format`: `prettier --write .`
+- `pnpm exec typecheck`: `tsc --noEmit`
 
 When run from the workspace root, these scripts will intelligently run recursively based on the contents of the workspace packages (e.g. `typecheck` will only run in workspace packages that have a `tsconfig.json` file).
 


### PR DESCRIPTION
Backslashes seem to be GitHub specific syntax (or at the very least, they don't work on NPM). They end up on a single line. This commit uses list syntax for listing the utility scripts (which works in NPM - see [discord.js](https://www.npmjs.com/package/discord.js/v/13.7.0#about) for example rendering). The following screenshot is from [version 1.6.11](https://www.npmjs.com/package/lionconfig/v/1.6.11#default-scripts).

![image](https://user-images.githubusercontent.com/27315593/168481683-fabcbf31-5b78-433f-b592-8170b908982c.png)
